### PR TITLE
Change CCFLAGS c++20 -> c++2a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ SOURCE_DIR := $(CURDIR)/src
 
 # compiler flags
 CC      := g++
-CCFLAGS := -Wall -O3 -Werror -std=c++20 -fPIC
+CCFLAGS := -Wall -O3 -Werror -std=c++2a -fPIC
 CCFLAGS += -I include
 CCFLAGS += -I $(SOURCE_DIR)/include
 CCFLAGS += -I $(PVLIB_HOME)/include


### PR DESCRIPTION
The versions of gcc (7 and 9) that are officially supported by arm fast models don't recognize -std=c++20. Newer gcc versions also -std=c++2a. 